### PR TITLE
Fix by replace tsserver with typescript for tree-sitter

### DIFF
--- a/custom/plugins/overrides.lua
+++ b/custom/plugins/overrides.lua
@@ -6,7 +6,7 @@ M.treesitter = {
     "lua",
     "html",
     "css",
-    "tsserver",
+    "typescript",
     "c",
   },
 }


### PR DESCRIPTION
Hello, 
When I tried the example config an error message came up because of the tree-sitter and the reason is because `tsserver` is the lsp of typescript and not the tree-sitter. 

This PR to fix it. 