### PR TITLE
Added example config for overriding theme highlights

### DIFF
--- a/custom/chadrc.lua
+++ b/custom/chadrc.lua
@@ -1,8 +1,12 @@
 local M = {}
 
+-- Path to overriding theme file
+local themes = require "custom.themes"
+
 M.ui = {
   theme_toggle = { "onedark", "one_light" },
   theme = "onedark",
+  changed_themes = themes,
 }
 
 M.plugins = require "custom.plugins"

--- a/custom/chadrc.lua
+++ b/custom/chadrc.lua
@@ -1,12 +1,15 @@
 local M = {}
 
--- Path to overriding theme file
-local themes = require "custom.themes"
+-- Path to overriding theme and highlights files
+local themes = require "custom.overidden_themes"
+local highlights = require "custom.highlights"
 
 M.ui = {
   theme_toggle = { "onedark", "one_light" },
   theme = "onedark",
   changed_themes = themes,
+  hl_override = highlights.override,
+  hl_add = highlights.add,
 }
 
 M.plugins = require "custom.plugins"

--- a/custom/highlights.lua
+++ b/custom/highlights.lua
@@ -1,0 +1,21 @@
+-- To find any highlight groups: "<cmd> Telescope highlights"
+-- Each highlight group can take a table with variables fg, bg, bold, italic, etc
+-- base30 variable names can also be used as colors
+
+local M = {}
+
+M.override = {
+  CursorLine = {
+    bg = "black2",
+  },
+  Comment = {
+    italic = true,
+  },
+}
+
+M.add = {
+  NvimTreeOpenedFolderName = { fg = "green", bold = true, italic = true },
+  NvimTreeOpenedFile = { fg = "teal", bold = true, italic = true },
+}
+
+return M

--- a/custom/overidden_themes.lua
+++ b/custom/overidden_themes.lua
@@ -1,8 +1,9 @@
-local M
-
 -- Follow same format for other themes and highlight groups
 -- For base_16 and base_30 variables: https://github.com/NvChad/base46
 -- Color can also be NONE for transparent or variable names (blue, white, etc)
+
+local M
+
 M = {
   tokyonight = {
     base_30 = {

--- a/custom/themes.lua
+++ b/custom/themes.lua
@@ -6,12 +6,12 @@ local M
 M = {
   tokyonight = {
     base_30 = {
-      statusline_bg = "#mycol",
+      statusline_bg = "NONE",
     },
   },
   onedark = {
     base_16 = {
-      base00 = "#mycol",
+      base00 = "blue",
     },
   },
 }

--- a/custom/themes.lua
+++ b/custom/themes.lua
@@ -1,0 +1,19 @@
+local M
+
+-- Follow same format for other themes and highlight groups
+-- For base_16 and base_30 variables: https://github.com/NvChad/base46
+-- Color can also be NONE for transparent or variable names (blue, white, darker_black, etc)
+M = {
+  tokyonight = {
+    base_30 = {
+      statusline_bg = "#mycol",
+    },
+  },
+  onedark = {
+    base_16 = {
+      base00 = "#mycol",
+    },
+  },
+}
+
+return M

--- a/custom/themes.lua
+++ b/custom/themes.lua
@@ -2,7 +2,7 @@ local M
 
 -- Follow same format for other themes and highlight groups
 -- For base_16 and base_30 variables: https://github.com/NvChad/base46
--- Color can also be NONE for transparent or variable names (blue, white, darker_black, etc)
+-- Color can also be NONE for transparent or variable names (blue, white, etc)
 M = {
   tokyonight = {
     base_30 = {

--- a/custom/themes.lua
+++ b/custom/themes.lua
@@ -11,7 +11,7 @@ M = {
   },
   onedark = {
     base_16 = {
-      base00 = "blue",
+      base0F = "red",
     },
   },
 }


### PR DESCRIPTION
# Feat: Added example config for overriding theme highlights

Since some people have been wondering how exactly to override some base46 theme configs, I've added an example to the repo.

I have also given the link to the base46 repo as reference for the variables.