### PR TITLE
Add comments for navigation in insert mode (not enabled by default)

### DIFF
--- a/mappings.lua
+++ b/mappings.lua
@@ -4,6 +4,16 @@ M.general = {
   n = {
     [";"] = { ":", "enter command mode", opts = { nowait = true } },
   },
+  i = {
+    -- If your terminal supports input disambiguation 
+    -- (i.e. Ctrl-I with Tab, Ctrl-H with Backspace)
+    -- Then you can consider uncommenting these lines to 
+    -- navigate within insert mode
+    -- ["<C-h>"] = { "<Left>", "move left" },
+    -- ["<C-l>"] = { "<Right>", "move right" },
+    -- ["<C-j>"] = { "<Down>", "move down" },
+    -- ["<C-k>"] = { "<Up>", "move up" },
+  }
 }
 
 -- more keybinds!


### PR DESCRIPTION
These keybinds are still usable for most terminal nowadays, so adding a comment section on the navigation inside insert mode keys 