### PR TITLE
:bug: change nvim-tree call inside plugins/init.lua

### DIFF
--- a/plugins/init.lua
+++ b/plugins/init.lua
@@ -21,7 +21,7 @@ return {
     override_options = overrides.mason,
   },
 
-  ["kyazdani42/nvim-tree.lua"] = {
+  ["nvim-tree/nvim-tree.lua"] = {
     override_options = overrides.nvimtree,
   },
 


### PR DESCRIPTION
Hi, was using the exemple_config and i had problems with nvim-tree charged two differents times.