### PR TITLE
Default show custom config in nvimtree

### DIFF
--- a/configs/overrides.lua
+++ b/configs/overrides.lua
@@ -44,6 +44,7 @@ M.mason = {
 M.nvimtree = {
   git = {
     enable = true,
+    ignore = false,
   },
 
   renderer = {


### PR DESCRIPTION
When installing the example custom config, the custom config directory and files are not shown in the NvChad's nvimtree. It is hidden by default.

The expected behaviour is that the custom config can be found and edited using NvChad.

It took me some time to figure it out. 
Anyway, this was a good lesson and here is my pull request if you find it useful.